### PR TITLE
材料の追加機能の実装

### DIFF
--- a/app/assets/javascripts/materials.coffee
+++ b/app/assets/javascripts/materials.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -216,5 +216,10 @@ h1, h2 {
       height: 110px;
     }
     
+    .step-edit {
+      display: flex;
+      padding: 10px;
+    }
+    
   }
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -158,7 +158,7 @@ h1, h2 {
     .recipe-title {
       padding-right: 20px;
       padding-left: 20px;
-      font-size: 25px;
+      font-size: 30px;
       font-weight: bolder;
     }
 
@@ -169,7 +169,14 @@ h1, h2 {
     
     .step-text {
       padding-right: 20px;
-      padding-left: 10px;
+      padding-left: 15px;
+      font-size: 20px;
+      font-weight: bold;
+    }
+    
+    .step-text-bold {
+      padding-right: 20px;
+      padding-left: 5px;
       font-size: 20px;
       font-weight: bold;
     }
@@ -205,8 +212,8 @@ h1, h2 {
     }
     
     .recipe-show-image {
-      width: 150px;
-      height: 100px;
+      width: 165px;
+      height: 110px;
     }
     
   }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -154,10 +154,29 @@ h1, h2 {
       padding-right: 20px;
       padding-left: 20px;
     }
+    
+    .recipe-title {
+      padding-right: 20px;
+      padding-left: 20px;
+      font-size: 25px;
+      font-weight: bolder;
+    }
 
     .recipe-text {
       padding-right: 20px;
       padding-left: 20px;
+    }
+    
+    .step-text {
+      padding-right: 20px;
+      padding-left: 10px;
+      font-size: 20px;
+      font-weight: bold;
+    }
+    
+    .step-description {
+      padding-right: 10px;
+      padding-left: 10px;
     }
 
     img {
@@ -184,5 +203,11 @@ h1, h2 {
         color: #565656;
       }
     }
+    
+    .recipe-show-image {
+      width: 150px;
+      height: 100px;
+    }
+    
   }
 }

--- a/app/assets/stylesheets/materials.scss
+++ b/app/assets/stylesheets/materials.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the materials controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,0 +1,21 @@
+class MaterialsController < ApplicationController
+  def new
+    @material = Material.new
+    @material.recipe_id = params[:recipe_id]
+  end
+  
+  def create
+    @material = Material.new(recipe_params)
+    if @material.save
+      redirect_to @material.recipe, success: '材料を追加しました'
+    else
+      flash.now[:danger] = "材料を追加できませんでした"
+      render :new
+    end
+  end
+  
+  private
+  def recipe_params
+    params.require(:material).permit(:title, :amount)
+  end
+end

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,17 +1,22 @@
 class MaterialsController < ApplicationController
   def new
     @material = Material.new
-    @material.recipe_id = params[:recipe_id]
   end
   
   def create
     @material = Material.new(recipe_params)
-    if @material.save
+    if @material.save&&Recipe_material.new(recipe_id: params[:recipe_id], material_id: @material.id).save
       redirect_to @material.recipe, success: '材料を追加しました'
     else
       flash.now[:danger] = "材料を追加できませんでした"
       render :new
     end
+  end
+  
+  def update
+  end
+  
+  def destory
   end
   
   private

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -5,8 +5,8 @@ class MaterialsController < ApplicationController
   
   def create
     @material = Material.new(recipe_params)
-    if @material.save&&Recipe_material.new(recipe_id: params[:recipe_id], material_id: @material.id).save
-      redirect_to @material.recipe, success: '材料を追加しました'
+    if @material.save && RecipeMaterial.new(recipe_id: params[:material][:recipe_id], material_id: @material.id).save
+      redirect_to Recipe.find(params[:material][:recipe_id]), success: '材料を追加しました'
     else
       flash.now[:danger] = "材料を追加できませんでした"
       render :new

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -1,7 +1,7 @@
 class StepsController < ApplicationController
   def new
     @step = Step.new
-    @recipe_id = params[:recipe_id]
+    @recipe = Recipe.find(params[:recipe_id])
   end
   
   def create

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -15,6 +15,12 @@ class StepsController < ApplicationController
     end
   end
   
+  def update
+  end
+  
+  def destory
+  end
+  
   private
   def recipe_params
     params.require(:step).permit(:recipe_id, :image, :description, :priority)

--- a/app/helpers/materials_helper.rb
+++ b/app/helpers/materials_helper.rb
@@ -1,0 +1,2 @@
+module MaterialsHelper
+end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,0 +1,7 @@
+class Material < ApplicationRecord
+  validates :title, presence: true
+  validates :amount, presence: true
+  
+  has_many :recipe_materials
+  has_many :recipes, :through => :recipe_materials
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -9,4 +9,7 @@ class Recipe < ApplicationRecord
   mount_uploader :image, ImageUploader
   
   has_many :steps
+  
+  has_many :recipe_materials
+  has_many :materials, :through => :recipe_materials
 end

--- a/app/models/recipe_material.rb
+++ b/app/models/recipe_material.rb
@@ -1,0 +1,4 @@
+class RecipeMaterial < ApplicationRecord
+  belongs_to :recipe
+  belongs_to :material
+end

--- a/app/views/materials/new.html.erb
+++ b/app/views/materials/new.html.erb
@@ -4,7 +4,7 @@
       <div class="col-md-6 col-md-offset-3">
         <h1 class="text-center">材料を追加</h1>
         <%= form_for @material do |f| %>
-          <%= f.hidden_field :recipe_id, value: @material.recipe_id %>
+          <%= f.hidden_field :recipe_id, value: params[:recipe_id] %>
           <div class="form-group">
             <%= f.label :食材名 %>
             <%= f.text_field :title %>

--- a/app/views/materials/new.html.erb
+++ b/app/views/materials/new.html.erb
@@ -1,0 +1,25 @@
+<div class="recipe-new-wrapper" >
+  <div class="container">
+    <div class="row">
+      <div class="col-md-6 col-md-offset-3">
+        <h1 class="text-center">材料を追加</h1>
+        <%= form_for @material do |f| %>
+          <%= f.hidden_field :recipe_id, value: @material.recipe_id %>
+          <div class="form-group">
+            <%= f.label :食材名 %>
+            <%= f.text_field :title %>
+          </div>
+          
+          <div class="form-group">
+            <%= f.label :数量 %>
+            <%= f.text_field :amount %>
+          </div>
+          
+          <% if logged_in? %>
+            <%= f.submit '追加', class: 'btn btn-black btn-block' %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -34,6 +34,10 @@
               <p class="step-description">
                 <%= step.description %>
               </p>
+              <div class="step-edit">
+                <%= link_to '編集', "#", class: 'step-description' %>
+                <%= link_to '削除', "#", class: 'step-description' %>
+              </div>
              </div>
             <% end %>
           </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -6,22 +6,26 @@
           <h2 class="recipe-author">
             <%= @recipe.user.name %>
           </h2>
-          <p class="recipe-text">
+          <p class="recipe-title">
             <%= @recipe.title %>
-          </p>  
-          <%= image_tag @recipe.image.url %>
+          </p>
           <p class="recipe-text">
             <%= @recipe.description %>
           </p>
-          <% @recipe.steps.each do |step| %>
-            <p class="recipe-text">
-              <%= step.priority %>
-            </p>
-            <%= image_tag step.image.url %>
-            <p class="recipe-text">
-              <%= step.description %>
-            </p>
-          <% end %>
+          <%= image_tag @recipe.image.url %>
+          <p class="step-text">手順</p>
+          <div class="row">
+            <% @recipe.steps.each do |step| %>
+              <div class="col-md-4">
+                <p class="step-text">
+                  <%= step.priority %>
+                </p>
+              <%= image_tag step.image.url, class: 'recipe-show-image' %>
+              <p class="step-description">
+                <%= step.description %>
+              </p>
+             </div>
+            <% end %>
           </div>
           <%= link_to '手順の追加', new_step_path(recipe_id: @recipe.id) , class: 'btn btn-block btn-black' %>
           <%= link_to '材料の追加', "#" , class: 'btn btn-block btn-black' %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -13,11 +13,21 @@
             <%= @recipe.description %>
           </p>
           <%= image_tag @recipe.image.url %>
+          <p class="step-text">材料</p>
+          <div class="row">
+            <% @recipe.materials.each do |material| %>
+              <p class="step-description">
+                <%= material.title %>
+                <%= material.amount %>
+              </p>
+            <% end %>
+          </div>
+          <%= link_to '材料の追加', new_material_path(recipe_id: @recipe.id), class: 'btn btn-block btn-black' %>
           <p class="step-text">手順</p>
           <div class="row">
             <% @recipe.steps.each do |step| %>
               <div class="col-md-4">
-                <p class="step-text">
+                <p class="step-text-bold">
                   <%= step.priority %>
                 </p>
               <%= image_tag step.image.url, class: 'recipe-show-image' %>
@@ -27,8 +37,7 @@
              </div>
             <% end %>
           </div>
-          <%= link_to '手順の追加', new_step_path(recipe_id: @recipe.id) , class: 'btn btn-block btn-black' %>
-          <%= link_to '材料の追加', "#" , class: 'btn btn-block btn-black' %>
+          <%= link_to '手順の追加', new_recipe_step_path(@recipe) , class: 'btn btn-block btn-black' %>
         </div>
       </div>
     </div>

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -3,8 +3,8 @@
     <div class="row">
       <div class="col-md-6 col-md-offset-3">
         <h1 class="text-center">手順を追加</h1>
-        <%= form_for @step do |f| %>
-          <%= f.hidden_field :recipe_id, value: @recipe_id %>
+        <%= form_for [@recipe, @step] do |f| %>
+          <%= f.hidden_field :recipe_id, value: @recipe.id %>
           <div class="form-group">
             <%= f.label :priority %>
             <%= f.text_field :priority %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,12 @@ Rails.application.routes.draw do
   get 'pages/help'
   
   resources :users
-  resources :recipes
-  resources :steps
+  resources :recipes do
+    resources :steps
+  end
   
+  resources :materials
+
   get    '/login',   to: 'sessions#new'
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'

--- a/db/migrate/20210520082833_create_materials.rb
+++ b/db/migrate/20210520082833_create_materials.rb
@@ -1,0 +1,10 @@
+class CreateMaterials < ActiveRecord::Migration[5.2]
+  def change
+    create_table :materials do |t|
+      t.string :title
+      t.float :amount
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210520084734_create_recipe_materials.rb
+++ b/db/migrate/20210520084734_create_recipe_materials.rb
@@ -1,0 +1,10 @@
+class CreateRecipeMaterials < ActiveRecord::Migration[5.2]
+  def change
+    create_table :recipe_materials do |t|
+      t.integer :recipe_id
+      t.integer :material_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_12_140630) do
+ActiveRecord::Schema.define(version: 2021_05_20_084734) do
+
+  create_table "materials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.float "amount"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "recipe_materials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "recipe_id"
+    t.integer "material_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "recipes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"

--- a/test/controllers/materials_controller_test.rb
+++ b/test/controllers/materials_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MaterialsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/materials.yml
+++ b/test/fixtures/materials.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  amount: 1.5
+
+two:
+  title: MyString
+  amount: 1.5

--- a/test/fixtures/recipe_materials.yml
+++ b/test/fixtures/recipe_materials.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/material_test.rb
+++ b/test/models/material_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MaterialTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/recipe_material_test.rb
+++ b/test/models/recipe_material_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RecipeMaterialTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
今回の主な実装内容は以下の３点です。

1. materialモデルを作成し、材料追加のページを作成した。
2. recipeとmaterialを繋ぐ中間テーブルを作り、recipeとmaterialを紐付けた(今回は「recipe_material」という名で作成)。
3. showページにおける手順のデザインを変更した。


